### PR TITLE
Refactor schema

### DIFF
--- a/app/graphql/mutations/accept_connection_request.rb
+++ b/app/graphql/mutations/accept_connection_request.rb
@@ -2,13 +2,13 @@
 
 module Mutations
   class AcceptConnectionRequest < Mutations::BaseMutation
-    argument :connection_id, ID, required: true
+    argument :connection_request_id, ID, required: true
 
     field :success, Boolean, null: false
     field :errors, [String], null: false
 
-    def resolve(connection_id:)
-      Connection.accept_request(connection_id)
+    def resolve(connection_request_id:)
+      ConnectionRequest.find(connection_request_id).accept
       { success: true, errors: [] }
     rescue => e
       { success: false, errors: [e.message] }

--- a/app/graphql/mutations/decline_connection_request.rb
+++ b/app/graphql/mutations/decline_connection_request.rb
@@ -2,13 +2,13 @@
 
 module Mutations
   class DeclineConnectionRequest < Mutations::BaseMutation
-    argument :connection_id, ID, required: true
+    argument :connection_request_id, ID, required: true
 
     field :success, Boolean, null: false
     field :errors, [String], null: false
 
-    def resolve(connection_id:)
-      Connection.decline_request(connection_id)
+    def resolve(connection_request_id:)
+      ConnectionRequest.find(connection_request_id).decline
       { success: true, errors: [] }
     rescue => e
       { success: false, errors: [e.message] }

--- a/app/graphql/mutations/remove_connection.rb
+++ b/app/graphql/mutations/remove_connection.rb
@@ -2,13 +2,14 @@
 
 module Mutations
   class RemoveConnection < Mutations::BaseMutation
-    argument :connection_id, ID, required: true
+    argument :sender_id, ID, required: true
+    argument :receiver_id, ID, required: true
 
     field :success, Boolean, null: false
     field :errors, [String], null: false
 
-    def resolve(connection_id:)
-      Connection.remove_connection(connection_id)
+    def resolve(sender_id:, receiver_id:)
+      Connection.disconnect(sender_id, receiver_id)
       { success: true, errors: [] }
     rescue => e
       { success: false, errors: [e.message] }

--- a/app/graphql/mutations/send_connection_request.rb
+++ b/app/graphql/mutations/send_connection_request.rb
@@ -2,14 +2,14 @@
 
 module Mutations
   class SendConnectionRequest < Mutations::BaseMutation
-    argument :requester_id, ID, required: true
-    argument :recipient_id, ID, required: true
+    argument :sender_id, ID, required: true
+    argument :receiver_id, ID, required: true
 
     field :success, Boolean, null: false
     field :errors, [String], null: false
 
-    def resolve(requester_id:, recipient_id:)
-      Connection.send_connection_request(requester_id, recipient_id)
+    def resolve(sender_id:, receiver_id:)
+      ConnectionRequest.create!(sender_id: sender_id, receiver_id: receiver_id)
       { success: true, errors: [] }
     rescue => e
       { success: false, errors: [e.message] }

--- a/app/graphql/types/connection_request_type.rb
+++ b/app/graphql/types/connection_request_type.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Types
+  class ConnectionRequestType < Types::BaseObject
+    field :id, ID, null: false
+    field :sender_id, Integer, null: false
+    field :receiver_id, Integer, null: false
+    field :status, String, null: false
+    field :responded_at, GraphQL::Types::ISO8601DateTime
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :sender, Types::UserType, null: false do
+      description "The user that sent the connection request"
+    end
+    field :receiver, Types::UserType, null: false do
+      description "The user that recieved the connection request"
+    end
+  end
+end

--- a/app/graphql/types/connection_type.rb
+++ b/app/graphql/types/connection_type.rb
@@ -3,16 +3,15 @@
 module Types
   class ConnectionType < Types::BaseObject
     field :id, ID, null: false
-    field :requester_id, Integer, null: false
-    field :recipient_id, Integer, null: false
-    field :status, String, null: false
+    field :user_id, Integer, null: false
+    field :connected_user_id, Integer, null: false
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
-    field :requester, Types::UserType, null: false do
-      description "The user who sent the connection request"
+    field :user, Types::UserType, null: false do
+      description "The user that this connection belongs to"
     end
-    field :recipient, Types::UserType, null: false do
-      description "The user who received the connection request"
+    field :connected_user, Types::UserType, null: false do
+      description "The other user that this user is connected to"
     end
   end
 end

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -15,19 +15,25 @@ module Types
     field :connections, [Types::UserType], null: true do
       description "All accepted connections for this user"
     end
-    field :pending_sent_requests, [Types::ConnectionType], null: true do
+    field :pending_sent_requests, [Types::ConnectionRequestType], null: true do
       description "Pending connection requests sent by this user"
     end
-    field :pending_received_requests, [Types::ConnectionType], null: true do
+    field :pending_received_requests, [Types::ConnectionRequestType], null: true do
       description "Pending connection requests received by this user"
     end
 
+    def connections
+      object.connected_users
+    end
+
+    # TODO: This includes isn't right. We need to use eager_load instead, and
+    # figure out what is being requested so we can do this more efficiently
     def pending_sent_requests
-      object.pending_sent_requests.includes(:recipient)
+      object.pending_sent_requests.includes(:receiver)
     end
 
     def pending_received_requests
-      object.pending_received_requests.includes(:requester)
+      object.pending_received_requests.includes(:sender)
     end
   end
 end

--- a/app/models/connection.rb
+++ b/app/models/connection.rb
@@ -8,6 +8,8 @@ class Connection < ApplicationRecord
   validates :user_id, uniqueness: { scope: :connected_user_id }
   validate :users_are_different
 
+  # TODO: Optimize these two queries for connect and disconnect
+
   # Create a mutual connection between two users. We create two records: one for
   # each user. This takes up more space but it makes queries for user
   # connections a lot less complex. Having tried using only one record

--- a/app/models/connection_request.rb
+++ b/app/models/connection_request.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class ConnectionRequest < ApplicationRecord
+  STATUSES = %w[pending accepted declined].freeze
+
+  belongs_to :sender, class_name: "User"
+  belongs_to :receiver, class_name: "User"
+
+  validates :sender_id, uniqueness: { scope: :receiver_id }
+  validates :status, inclusion: { in: STATUSES }
+  validate :users_are_different
+
+  scope :pending, -> { where(status: "pending") }
+  scope :accepted, -> { where(status: "accepted") }
+  scope :declined, -> { where(status: "declined") }
+
+  def accept
+    transaction do
+      update!(status: "accepted", responded_at: Time.current)
+      Connection.connect(sender_id, receiver_id)
+    end
+  end
+
+  def decline
+    update!(status: "declined", responded_at: Time.current)
+  end
+
+  private
+
+    def users_are_different
+      errors.add(:receiver_id, "can't be same as sender") if sender_id == receiver_id
+    end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,12 @@ class User < ApplicationRecord
 
   validates :first_name, presence: true
   validates :last_name, presence: true
+
+  def pending_sent_requests
+    sent_connection_requests.pending
+  end
+
+  def pending_received_requests
+    received_connection_requests.pending
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,25 +3,9 @@
 class User < ApplicationRecord
   belongs_to :company
 
-  has_many :sent_connections, class_name: "Connection", foreign_key: "requester_id", dependent: :destroy
-  has_many :received_connections, class_name: "Connection", foreign_key: "recipient_id", dependent: :destroy
+  has_many :connections
+  has_many :connected_users, through: :connections
 
   validates :first_name, presence: true
   validates :last_name, presence: true
-
-  def connections
-    # Get all the user ids, removing this user from the array
-    user_ids = Connection
-      .user_connections(self)
-      .pluck(:requester_id, :recipient_id).flatten - [id]
-    User.where(id: user_ids)
-  end
-
-  def pending_sent_requests
-    sent_connections.pending
-  end
-
-  def pending_received_requests
-    received_connections.pending
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,9 +2,10 @@
 
 class User < ApplicationRecord
   belongs_to :company
-
   has_many :connections
   has_many :connected_users, through: :connections
+  has_many :sent_connection_requests, class_name: "ConnectionRequest", foreign_key: :sender_id
+  has_many :received_connection_requests, class_name: "ConnectionRequest", foreign_key: :receiver_id
 
   validates :first_name, presence: true
   validates :last_name, presence: true

--- a/db/migrate/20250824120000_create_connections.rb
+++ b/db/migrate/20250824120000_create_connections.rb
@@ -1,13 +1,11 @@
-class CreateConnections < ActiveRecord::Migration[6.0]
+class CreateConnections < ActiveRecord::Migration[8.0]
   def change
     create_table :connections do |t|
-      t.references :requester, null: false, foreign_key: { to_table: :users }
-      t.references :recipient, null: false, foreign_key: { to_table: :users }
-      t.string :status, null: false, default: 'pending'
+      t.references :user, null: false, foreign_key: true
+      t.references :connected_user, null: false, foreign_key: { to_table: :users }
       t.timestamps
     end
 
-    add_index :connections, [:requester_id, :recipient_id], unique: true
-    add_index :connections, :status
+    add_index :connections, [:user_id, :connected_user_id], unique: true
   end
 end

--- a/db/migrate/20250904034455_create_connection_requests.rb
+++ b/db/migrate/20250904034455_create_connection_requests.rb
@@ -1,0 +1,13 @@
+class CreateConnectionRequests < ActiveRecord::Migration[8.0]
+  def change
+    create_table :connection_requests do |t|
+      t.references :sender, null: false, foreign_key: { to_table: :users }
+      t.references :receiver, null: false, foreign_key: { to_table: :users }
+      t.string :status, null: false, default: 'pending'
+      t.datetime :responded_at
+      t.timestamps
+    end
+
+    add_index :connection_requests, [:sender_id, :receiver_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,15 +20,13 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_25_005509) do
   end
 
   create_table "connections", force: :cascade do |t|
-    t.integer "requester_id", null: false
-    t.integer "recipient_id", null: false
-    t.string "status", default: "pending", null: false
+    t.integer "user_id", null: false
+    t.integer "connected_user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["recipient_id"], name: "index_connections_on_recipient_id"
-    t.index ["requester_id", "recipient_id"], name: "index_connections_on_requester_id_and_recipient_id", unique: true
-    t.index ["requester_id"], name: "index_connections_on_requester_id"
-    t.index ["status"], name: "index_connections_on_status"
+    t.index ["connected_user_id"], name: "index_connections_on_connected_user_id"
+    t.index ["user_id", "connected_user_id"], name: "index_connections_on_user_id_and_connected_user_id", unique: true
+    t.index ["user_id"], name: "index_connections_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -43,7 +41,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_25_005509) do
     t.index ["company_id"], name: "index_users_on_company_id"
   end
 
-  add_foreign_key "connections", "users", column: "recipient_id"
-  add_foreign_key "connections", "users", column: "requester_id"
+  add_foreign_key "connections", "users"
+  add_foreign_key "connections", "users", column: "connected_user_id"
   add_foreign_key "users", "companies"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_25_005509) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_04_034455) do
   create_table "companies", force: :cascade do |t|
     t.text "name", null: false
     t.text "headquarters", null: false
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "connection_requests", force: :cascade do |t|
+    t.integer "sender_id", null: false
+    t.integer "receiver_id", null: false
+    t.string "status", default: "pending", null: false
+    t.datetime "responded_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["receiver_id"], name: "index_connection_requests_on_receiver_id"
+    t.index ["sender_id", "receiver_id"], name: "index_connection_requests_on_sender_id_and_receiver_id", unique: true
+    t.index ["sender_id"], name: "index_connection_requests_on_sender_id"
   end
 
   create_table "connections", force: :cascade do |t|
@@ -41,6 +53,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_25_005509) do
     t.index ["company_id"], name: "index_users_on_company_id"
   end
 
+  add_foreign_key "connection_requests", "users", column: "receiver_id"
+  add_foreign_key "connection_requests", "users", column: "sender_id"
   add_foreign_key "connections", "users"
   add_foreign_key "connections", "users", column: "connected_user_id"
   add_foreign_key "users", "companies"

--- a/spec/factories/connection_requests.rb
+++ b/spec/factories/connection_requests.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :connection_request do
+    association :sender, factory: :house
+    association :receiver, factory: :wilson
+  end
+end

--- a/spec/factories/connections.rb
+++ b/spec/factories/connections.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :connection do
-    association :requester, factory: :house
-    association :recipient, factory: :wilson
-    status { "accepted" }
+    association :user, factory: :house
+    association :connected_user, factory: :wilson
   end
 end

--- a/spec/models/connection_request_spec.rb
+++ b/spec/models/connection_request_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe ConnectionRequest, type: :model do
+  let(:house) { create(:house) }
+  let(:wilson)  { create(:wilson) }
+
+  describe "validation" do
+    describe "users_are_different" do
+      it "is invalid if sender and receiver are the same user" do
+        request = build(:connection_request, sender: house, receiver: house)
+        expect(request).not_to be_valid
+        expect(request.errors[:receiver_id]).to include("can't be same as sender")
+      end
+    end
+  end
+
+  describe "#accept" do
+    it "accepts a pending connection request" do
+      request = create(:connection_request, sender: house, receiver: wilson)
+      # Make sure test for responded_at is deterministic by using freeze_time
+      freeze_time do
+        now = Time.current
+        request.accept
+        request.reload
+        expect(request.responded_at).to eq(now)
+      end
+
+      expect(request.status).to eq("accepted")
+      expect(request.sender.connected_users).to include(wilson)
+      expect(request.receiver.connected_users).to include(house)
+    end
+  end
+
+  describe "#decline" do
+    it "declines a pending connection request" do
+      request = create(:connection_request, sender: house, receiver: wilson)
+      freeze_time do
+        now = Time.current
+        request.decline
+        request.reload
+        expect(request.responded_at).to eq(now)
+      end
+
+      expect(request.status).to eq("declined")
+      expect(request.sender.connected_users).not_to include(wilson)
+      expect(request.receiver.connected_users).not_to include(house)
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,45 +4,31 @@ RSpec.describe User, type: :model do
   let(:house) { create(:house) }
   let(:wilson)  { create(:wilson) }
   let(:cameron) { create(:cameron) }
-  let(:cuddy) { create(:cuddy) }
   let(:thirteen) { create(:thirteen) }
-
-  describe "#connections" do
-    it "returns all accepted connections for a user" do
-      create(:connection, requester: house, recipient: wilson, status: "accepted")
-      create(:connection, requester: cuddy, recipient: house, status: "pending")
-      create(:connection, requester: house, recipient: thirteen, status: "declined")
-
-      expect(house.connections).to include(wilson)
-
-      expect(house.connections).not_to include(cuddy)
-      expect(house.connections).not_to include(thirteen)
-    end
-  end
 
   describe "#pending_sent_requests" do
     it "returns sent connection requests that are still pending" do
-      pending_connection = create(:connection, requester: house, recipient: thirteen, status: "pending")
-      accepted_connection = create(:connection, requester: house, recipient: wilson, status: "accepted")
-      declined_connection = create(:connection, requester: house, recipient: cameron, status: "declined")
+      pending_request = create(:connection_request, sender: house, receiver: thirteen, status: "pending")
+      accepted_request = create(:connection_request, sender: house, receiver: wilson, status: "accepted")
+      declined_request = create(:connection_request, sender: house, receiver: cameron, status: "declined")
 
-      expect(house.pending_sent_requests).to include(pending_connection)
+      expect(house.pending_sent_requests).to include(pending_request)
 
-      expect(house.pending_sent_requests).not_to include(accepted_connection)
-      expect(house.pending_sent_requests).not_to include(declined_connection)
+      expect(house.pending_sent_requests).not_to include(accepted_request)
+      expect(house.pending_sent_requests).not_to include(declined_request)
     end
   end
 
   describe "#pending_received_requests" do
     it "returns received connection requests that are still pending" do
-      pending_connection = create(:connection, requester: thirteen, recipient: house, status: "pending")
-      accepted_connection = create(:connection, requester: wilson, recipient: house, status: "accepted")
-      declined_connection = create(:connection, requester: cameron, recipient: house, status: "declined")
+      pending_request = create(:connection_request, sender: thirteen, receiver: house, status: "pending")
+      accepted_request = create(:connection_request, sender: wilson, receiver: house, status: "accepted")
+      declined_request = create(:connection_request, sender: cameron, receiver: house, status: "declined")
 
-      expect(house.pending_received_requests).to include(pending_connection)
+      expect(house.pending_received_requests).to include(pending_request)
 
-      expect(house.pending_received_requests).not_to include(accepted_connection)
-      expect(house.pending_received_requests).not_to include(declined_connection)
+      expect(house.pending_received_requests).not_to include(accepted_request)
+      expect(house.pending_received_requests).not_to include(declined_request)
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -74,5 +74,6 @@ RSpec.configure do |config|
   # build, etc.
   RSpec.configure do |config|
     config.include FactoryBot::Syntax::Methods
+    config.include ActiveSupport::Testing::TimeHelpers
   end
 end


### PR DESCRIPTION
Changed the database schema and the API.

- Changed Connection model so that each connection requires a record for both connected users. The queries involved with having one record for both users felt too complicated. It felt somewhat like I was fighting the framework, and to some extent the relational paradigm, in order to make things feel more efficient or simple when in fact I was creating more complexity. The new paradigm uses more storage but feels more like Rails is doing the heavy lifting for my db queries. Most things can now be done via simple relations.
- Created a separate ConnectionRequest model. The Connection model was previously handling this. It felt like too much responsibility for one model. This time the trade-off still adds a bit more storage but feels like it fits better within the paradigm we're using, and is more loosely coupled.
- Changed the GraphQL types to accommodate the new changes. Normally we might try to adapt the existing GraphQL API to accommodate these changes without changing the API, but since no one is using it but me I get to mess with the contract a little without any real penalty.